### PR TITLE
Updated steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 ## Getting Started
 * Type `sudo nano /etc/ssh/sshd_config`
-* Scroll Down until you see `#PermitRootLogin prohibit-password` change that to `PermitRootLogin yes` then Save.
-* Type `sudo passwd your_password` - Enter New Password, then again.
-* Once that is done do `service sshd restart`
-* Then login using user `root` and password `your_password`
+* Scroll Down until you see `#PermitRootLogin prohibit-password` change that to `PermitRootLogin yes` then save
+* Type `sudo passwd root` - Enter New Password, then again
+* Once that is done do `service sshd restart` - you may need to confirm the `ubuntu` password
+* Then login using user `root` and password you created
 
 
 Hope it works for you.


### PR DESCRIPTION
- Updated the steps in the guide to account for newer Ubuntu versions by using `sudo passwd root` instead.